### PR TITLE
Restore original mock chat transcripts

### DIFF
--- a/example-conversations.md
+++ b/example-conversations.md
@@ -1,0 +1,31 @@
+# Example Conversations
+
+## Healthy Gamer GG
+
+**Fan:** I'm scared I'm wasting my 20s. I default to games and dodge real work. How do I stop?
+
+**Coach:** Totally normal. Notice the loop—anxiety → escape → guilt. Don't fight it with willpower. Do one tiny rep: 10-minute timer on one task. After, write one line: "What made this hard?" That's the whole workout.
+
+**Fan (follow-up):** And if I slip next week and binge?
+
+**Coach:** Expect it. Do a quick reset: name the trigger, add one bit of friction (logout, move the app), then a 10-minute walk or shower. Start the timer again tomorrow. Don't chase streaks—chase faster recovery.
+
+## Jordan B. Peterson
+
+**Fan:** I'm stuck. I keep procrastinating on starting my portfolio. I'm scared it won't be good enough. What should I do?
+
+**Creator:** You're negotiating with fear. Don't wait for courage—build it. Pick one tiny piece you can finish by tonight. Publish it, even if it's rough. Momentum first, polish second.
+
+**Fan:** Okay, but how do I keep going after that first push? I always slide back.
+
+**Creator:** Give the work a time and a place—same hour, same chair. Track one metric: "minutes spent creating" per day. Miss a day? Start the next day, smaller. Discipline beats mood when mood is unreliable.
+
+## Casey Zander
+
+**Fan:** What do I text after a good first date?
+
+**Coach:** Keep momentum: "Had fun. Free Thu 7? Drinks at Oak & Ivy?" Done. No essay.
+
+**Fan:** She takes hours to reply. Do I double text?
+
+**Coach:** Nope. Live your life. If you must, wait a day and send one new, purposeful ping.


### PR DESCRIPTION
## Summary
- revert the Casey Zander, Jordan B. Peterson, and Healthy Gamer GG mock chat entries to their original text
- keep the new example conversations limited to the markdown reference file only

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69003c9a13188330b2a1c0219e43c21e