### PR TITLE
fix: stabilize navbar rendering in Atlas

### DIFF
--- a/app/components/navbar-navigation.client.tsx
+++ b/app/components/navbar-navigation.client.tsx
@@ -18,7 +18,7 @@ function NavbarNavigationComponent({ menu }: NavbarNavigationProps) {
   }
 
   return (
-    <div className="flex items-center md:hidden gap-2 ml-auto">
+    <div className="ml-auto flex items-center gap-2 lg:hidden">
       <button
         type="button"
         className="flex items-end p-2"
@@ -33,14 +33,14 @@ function NavbarNavigationComponent({ menu }: NavbarNavigationProps) {
       {isOpen ? (
         <div
           id={menuId}
-          className="flex flex-col items-center w-48 px-2 pt-4 pb-2 bg-white dark:bg-black absolute top-22 right-6 border border-gray-100 rounded-md z-10"
+          className="absolute right-6 top-22 z-30 flex w-52 flex-col items-center rounded-md border border-gray-200 bg-white px-2 pt-4 pb-2 shadow-lg dark:border-gray-800 dark:bg-black"
         >
           {menu.map((item) => (
             <a
               href={item.url}
               key={item.url}
               onClick={handleMenu}
-              className="text-left group inline-flex h-10 w-full pr-4 mb-2 items-center justify-end text-xl font-semibold transition-colors"
+              className="mb-2 inline-flex h-10 w-full items-center justify-end pr-4 text-left text-xl font-semibold text-foreground transition-colors hover:text-blue-600 dark:hover:text-blue-400"
             >
               {item.title}
             </a>

--- a/app/components/navbar1.tsx
+++ b/app/components/navbar1.tsx
@@ -39,16 +39,20 @@ const defaultMenu: MenuItem[] = [
 
 export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props) {
   return (
-    <section className="sticky top-0 z-10 border-b backdrop-blur-md py-4">
+    <section className="sticky top-0 z-20 border-b border-gray-200/70 bg-white/85 py-4 backdrop-blur-md dark:border-gray-800/80 dark:bg-black/75">
       <div className="w-full mx-auto max-w-[98rem]">
-        <nav className="flex items-center w-11/12 mx-auto gap-8">
-          <a href={logo.url} className="flex items-center gap-2" aria-label={logo.title}>
+        <nav className="flex items-center w-11/12 mx-auto gap-4 lg:gap-8">
+          <a
+            href={logo.url}
+            className="flex shrink-0 items-center gap-2"
+            aria-label={logo.title}
+          >
             <Image src={logo.srcLight} width={64} height={64} className="h-16 w-auto sm:h-14 lg:h-12 dark:hidden" alt={logo.alt} />
             <Image src={logo.srcDark} width={64} height={64} className="h-16 w-auto sm:h-14 lg:h-12 hidden dark:block" alt={logo.alt} />
           </a>
 
-          <div className="flex items-center gap-6 justify-end w-full">
-            <ul className="hidden md:flex items-center gap-2 md:gap-3 lg:gap-4 lg:text-xl">
+          <div className="flex min-w-0 flex-1 items-center justify-end gap-4 lg:gap-6">
+            <ul className="hidden lg:flex flex-1 items-center justify-end gap-2 xl:gap-4 lg:text-lg xl:text-xl">
               {menu.map((item) => (
                 <li key={item.url} className="shrink-0">
                   <a
@@ -56,7 +60,7 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
                     className={
                       item.button
                         ? "bg-blue-600 hover:bg-blue-500 text-white inline-flex h-10 items-center rounded-md px-3 md:px-4 py-2 font-semibold transition-colors whitespace-nowrap"
-                        : "bg-background hover:bg-muted hover:text-accent-foreground inline-flex h-10 items-center rounded-md px-3 md:px-4 py-2 font-semibold transition-colors whitespace-nowrap"
+                        : "inline-flex h-10 items-center rounded-md px-3 py-2 font-semibold text-foreground transition-colors whitespace-nowrap hover:bg-gray-100 dark:hover:bg-gray-800"
                     }
                   >
                     {item.title}
@@ -65,7 +69,7 @@ export function Navbar1({ logo = defaultLogo, menu = defaultMenu }: Navbar1Props
               ))}
             </ul>
 
-            <div className="flex items-center gap-4">
+            <div className="flex shrink-0 items-center gap-3 lg:gap-4">
               <DarkModeToggle />
               <NavbarNavigation menu={menu} />
             </div>


### PR DESCRIPTION
## Summary
- move the desktop navbar to `lg` and keep the hamburger menu active below that width
- make the navbar flex layout more resilient so the logo, links, and controls do not fight for space
- add explicit navbar background and link colors so link visibility does not depend on browser-specific rendering quirks

## Root cause
The navbar enabled the full desktop link row starting at the `md` breakpoint. At medium widths this layout was already too tight, so browser-specific width and font-metric differences could push the link row into a bad render state where the items were effectively not visible. The navbar also relied on inherited text/background styling for the non-button links, which made the visibility path more brittle than it needed to be.

## Verification
- `npm run build`
- checked the local navbar in WebKit at `900px` (hamburger path) and `1280px` (desktop link row) using Playwright screenshots