### PR TITLE
[codex] Add blog copy refinement tracking

### DIFF
--- a/app/lib/blog-types.ts
+++ b/app/lib/blog-types.ts
@@ -9,6 +9,10 @@ export interface BlogPost {
 	angle: string
 }
 
+export interface StoredBlogPost extends BlogPost {
+	copyRefinedAt?: string
+}
+
 export interface GeneratedBlogPost extends BlogPost {
 	cta: string
 }

--- a/app/lib/blog.ts
+++ b/app/lib/blog.ts
@@ -1,26 +1,41 @@
-import type { BlogPost } from '@/app/lib/blog-types'
+import type { BlogPost, StoredBlogPost } from '@/app/lib/blog-types'
 import blogPosts from '@/content/blog/posts.json'
 
-const staticPosts = blogPosts as BlogPost[]
+const storedPosts = blogPosts as StoredBlogPost[]
 
 export const replyFanBenefitAngles = [
 	'Passive income without extra screen time',
 	'24/7 fan access without creator burnout',
 	'Turning fan questions into a scalable product',
-	'Helping fans get answers in the creator’s voice',
+	'Helping fans get answers in the creator\'s voice',
 	'Monetizing attention without hiring a team',
 	'Keeping creator knowledge available after every upload',
 	'Making fan relationships deeper without adding manual replies',
 	'Launching a digital twin with no upfront operational work',
 ] as const
 
+function toBlogPost (post: StoredBlogPost): BlogPost {
+	return {
+		title: post.title,
+		slug: post.slug,
+		excerpt: post.excerpt,
+		content: post.content,
+		publishedAt: post.publishedAt,
+		readTimeMinutes: post.readTimeMinutes,
+		tags: post.tags,
+		angle: post.angle,
+	}
+}
+
 export function getAllBlogPosts (): BlogPost[] {
-	return [...staticPosts].sort((firstPost, secondPost) => {
+	return [...storedPosts]
+		.sort((firstPost, secondPost) => {
 		return (
 			new Date(secondPost.publishedAt).getTime() -
 			new Date(firstPost.publishedAt).getTime()
 		)
 	})
+		.map(toBlogPost)
 }
 
 export function getBlogPostBySlug (slug: string): BlogPost | undefined {
@@ -36,5 +51,5 @@ export function getRandomBenefitAngle (): string {
 }
 
 export function getBlogPostSlugs (): string[] {
-	return staticPosts.map((post) => post.slug)
+	return storedPosts.map((post) => post.slug)
 }

--- a/content/blog/posts.json
+++ b/content/blog/posts.json
@@ -13,7 +13,8 @@
 			"ReplyFan",
 			"creators"
 		],
-		"angle": "Making fan relationships deeper without adding manual replies"
+		"angle": "Making fan relationships deeper without adding manual replies",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Keep Creator Knowledge Available After Every Upload",
@@ -29,7 +30,8 @@
 			"passive-income",
 			"YouTube"
 		],
-		"angle": "Keeping creator knowledge available after every upload"
+		"angle": "Keeping creator knowledge available after every upload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "24/7 Fan Access Without Creator Burnout",
@@ -45,7 +47,8 @@
 			"passive income",
 			"ReplyFan"
 		],
-		"angle": "24/7 fan access without creator burnout"
+		"angle": "24/7 fan access without creator burnout",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Keep Your Knowledge Alive After Every Upload",
@@ -61,7 +64,8 @@
 			"monetization",
 			"content lifecycle"
 		],
-		"angle": "Keeping creator knowledge available after every upload"
+		"angle": "Keeping creator knowledge available after every upload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Launch a Digital Twin Without Running It Yourself",
@@ -78,7 +82,8 @@
 			"fan-engagement",
 			"ReplyFan"
 		],
-		"angle": "Launching a digital twin with no upfront operational work"
+		"angle": "Launching a digital twin with no upfront operational work",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Launch a Digital Twin with Zero Operational Work",
@@ -95,7 +100,8 @@
 			"fan-engagement",
 			"ReplyFan"
 		],
-		"angle": "Launching a digital twin with no upfront operational work"
+		"angle": "Launching a digital twin with no upfront operational work",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Give Fans Answers in Your Voice, 24/7",
@@ -110,7 +116,8 @@
 			"creator tools",
 			"passive income"
 		],
-		"angle": "Helping fans get answers in the creator's voice"
+		"angle": "Helping fans get answers in the creator's voice",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Answers in Your Voice: Give Fans Instant, 24/7 Access",
@@ -125,7 +132,8 @@
 			"creator tools",
 			"passive income"
 		],
-		"angle": "Helping fans get answers in the creator's voice"
+		"angle": "Helping fans get answers in the creator's voice",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Turn Fan Access Into Revenue Without More Screen Time",
@@ -142,7 +150,8 @@
 			"ReplyFan",
 			"monetization"
 		],
-		"angle": "Passive income without extra screen time"
+		"angle": "Passive income without extra screen time",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Passive income without extra screen time",
@@ -159,7 +168,8 @@
 			"ReplyFan",
 			"monetization"
 		],
-		"angle": "Passive income without extra screen time"
+		"angle": "Passive income without extra screen time",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Monetize Attention Without Hiring a Team",
@@ -176,7 +186,8 @@
 			"fan engagement",
 			"ReplyFan"
 		],
-		"angle": "Monetizing attention without hiring a team"
+		"angle": "Monetizing attention without hiring a team",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Monetize Attention Without Hiring a Team: Use a Digital Twin",
@@ -193,7 +204,8 @@
 			"fan engagement",
 			"ReplyFan"
 		],
-		"angle": "Monetizing attention without hiring a team"
+		"angle": "Monetizing attention without hiring a team",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Monetize Fan Attention Without Hiring a Team",
@@ -208,7 +220,8 @@
 			"digital twin",
 			"passive income"
 		],
-		"angle": "Monetizing attention without hiring a team"
+		"angle": "Monetizing attention without hiring a team",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Let Every Upload Keep Working for You",
@@ -223,7 +236,8 @@
 			"content workflow",
 			"fan engagement"
 		],
-		"angle": "Keeping creator knowledge available after every upload"
+		"angle": "Keeping creator knowledge available after every upload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Deeper Fan Relationships Without Writing More Replies",
@@ -238,7 +252,8 @@
 			"creator economy",
 			"digital twin"
 		],
-		"angle": "Making fan relationships deeper without adding manual replies"
+		"angle": "Making fan relationships deeper without adding manual replies",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Turn Every Upload Into a Searchable Asset",
@@ -253,7 +268,8 @@
 			"content library",
 			"passive income"
 		],
-		"angle": "Keeping creator knowledge available after every upload"
+		"angle": "Keeping creator knowledge available after every upload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Passive Income Without Extra Screen Time",
@@ -268,7 +284,8 @@
 			"digital twin",
 			"fan engagement"
 		],
-		"angle": "Passive income without extra screen time"
+		"angle": "Passive income without extra screen time",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Keep Your Explanations Available 24/7",
@@ -283,7 +300,8 @@
 			"knowledge retention",
 			"fan engagement"
 		],
-		"angle": "Keeping creator knowledge available after every upload"
+		"angle": "Keeping creator knowledge available after every upload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Launch a Digital Twin Without an Ops Burden",
@@ -298,7 +316,8 @@
 			"monetization",
 			"creator tools"
 		],
-		"angle": "Launching a digital twin with no upfront operational work"
+		"angle": "Launching a digital twin with no upfront operational work",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Turn Every Upload Into an Evergreen Answer Hub",
@@ -313,7 +332,8 @@
 			"fan engagement",
 			"creator business"
 		],
-		"angle": "Keeping creator knowledge available after every upload"
+		"angle": "Keeping creator knowledge available after every upload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Fans Want Answers in Your Voice, Not a Generic Bot",
@@ -328,7 +348,8 @@
 			"fan engagement",
 			"creator voice"
 		],
-		"angle": "Helping fans get answers in the creator's voice"
+		"angle": "Helping fans get answers in the creator's voice",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Your Content Keeps Working After You Log Off",
@@ -342,7 +363,8 @@
 			"digital twin",
 			"creator business"
 		],
-		"angle": "Keeping creator knowledge available after every upload"
+		"angle": "Keeping creator knowledge available after every upload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Deeper Fan Relationships Without Manual Replies",
@@ -356,7 +378,8 @@
 			"fan engagement",
 			"creator economy"
 		],
-		"angle": "Making fan relationships deeper without adding manual replies"
+		"angle": "Making fan relationships deeper without adding manual replies",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Digital Twins Turn Fan Access Into a Product",
@@ -370,7 +393,8 @@
 			"digital twin",
 			"fan access"
 		],
-		"angle": "ReplyFan creates passive income without adding creator workload"
+		"angle": "ReplyFan creates passive income without adding creator workload",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Passive Income Without More Screen Time",
@@ -384,7 +408,8 @@
 			"passive income",
 			"creator business"
 		],
-		"angle": "ReplyFan lets influencers monetize attention without hiring a team"
+		"angle": "ReplyFan lets influencers monetize attention without hiring a team",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	},
 	{
 		"title": "Why Fans Want 24/7 Access to a Creator Twin",
@@ -398,6 +423,7 @@
 			"24/7 access",
 			"fan engagement"
 		],
-		"angle": "Fans can talk to a creator's digital twin 24/7"
+		"angle": "Fans can talk to a creator's digital twin 24/7",
+		"copyRefinedAt": "2026-04-05T16:30:00.000Z"
 	}
 ]

--- a/docs/blog-storage.md
+++ b/docs/blog-storage.md
@@ -1,0 +1,26 @@
+# Blog Storage
+
+Blog posts are stored in `content/blog/posts.json`.
+
+Each post record uses this shape:
+
+```json
+{
+	"title": "Post title",
+	"slug": "post-slug",
+	"excerpt": "Short summary",
+	"content": "Post body",
+	"publishedAt": "2026-04-05T00:00:00.000Z",
+	"readTimeMinutes": 2,
+	"tags": ["replyfan"],
+	"angle": "Benefit angle",
+	"copyRefinedAt": "2026-04-05T16:30:00.000Z"
+}
+```
+
+Notes:
+
+- `copyRefinedAt` is optional.
+- `copyRefinedAt` is internal only and should not be displayed in the UI.
+- New generated posts can omit `copyRefinedAt` until somebody manually refines the copy.
+- Existing posts can be backfilled with one shared timestamp when refinement tracking is introduced.

--- a/scripts/generate-blog-post.mjs
+++ b/scripts/generate-blog-post.mjs
@@ -5,6 +5,20 @@ import process from 'node:process'
 const blogPostsPath = path.join(process.cwd(), 'content/blog/posts.json')
 const defaultModel = process.env.OPENAI_BLOG_MODEL || 'gpt-5-mini'
 
+/**
+ * @typedef {{
+ *   title: string
+ *   slug: string
+ *   excerpt: string
+ *   content: string
+ *   publishedAt: string
+ *   readTimeMinutes: number
+ *   tags: string[]
+ *   angle: string
+ *   copyRefinedAt?: string
+ * }} StoredBlogPost
+ */
+
 const replyFanBenefitAngles = [
 	'Passive income without extra screen time',
 	'24/7 fan access without creator burnout',
@@ -81,6 +95,19 @@ function createUniqueSlug (value, existingPosts) {
 	}
 
 	return `${datedSlug}-${Date.now()}`
+}
+
+/**
+ * @returns {Promise<StoredBlogPost[]>}
+ */
+async function readExistingPosts () {
+	const posts = JSON.parse(await readFile(blogPostsPath, 'utf8'))
+
+	if (!Array.isArray(posts)) {
+		throw new Error('Blog post storage must be a JSON array.')
+	}
+
+	return posts
 }
 
 async function generatePost (angle) {
@@ -171,10 +198,11 @@ async function generatePost (angle) {
 }
 
 async function main () {
-	const existingPosts = JSON.parse(await readFile(blogPostsPath, 'utf8'))
+	const existingPosts = await readExistingPosts()
 	const angle = getRandomBenefitAngle()
 	const generatedPost = await generatePost(angle)
 
+	/** @type {StoredBlogPost} */
 	const newPost = {
 		title: generatedPost.title,
 		slug: createUniqueSlug(generatedPost.title, existingPosts),


### PR DESCRIPTION
## What changed
- added internal `copyRefinedAt` support to the blog storage types
- kept `content/blog/posts.json` as the source of truth instead of migrating storage format
- updated the blog read layer to strip `copyRefinedAt` back out of the public blog objects so it stays internal
- documented the JSON blog storage shape in `docs/blog-storage.md`
- backfilled every existing blog post with the same `copyRefinedAt` timestamp
- updated the blog generation script typings/read path so existing stored fields continue to round-trip cleanly

## Why
We need a simple internal signal for whether blog copy has been manually refined, without changing user-facing blog UI.

## Notes
- backfill timestamp used for existing posts: `2026-04-05T16:30:00.000Z`
- new generated posts can omit `copyRefinedAt` until they are manually refined
- no UI changes were made

## Validation
- confirmed all 26 blog posts now include `copyRefinedAt`
- `content/blog/posts.json` parses successfully
- `npm run lint` passes with two existing warnings in `app/components/animated-tooltip.tsx`
